### PR TITLE
Removed Google Analytics from template

### DIFF
--- a/templates/javascripts.html
+++ b/templates/javascripts.html
@@ -13,13 +13,4 @@
 
 	<!-- Material Dashboard javascript methods -->
     <script src="{{ url_for('static', filename='js/material-dashboard.js')}}"></script>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-79152918-1', 'auto');
-      ga('send', 'pageview');
-    </script>
 {% endblock %}


### PR DESCRIPTION
Removed the script block that loaded Google Analytics script.
Because we respect the user's privacy :-) 

Signed-off-by: Aitor Cedres <acedres@pivotal.io>